### PR TITLE
feat:Remove value property from BooleanCell, NumberCell, and StringCell schemas

### DIFF
--- a/src/libs/Instill/Generated/Instill.Models.BooleanCell.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.BooleanCell.g.cs
@@ -9,13 +9,6 @@ namespace Instill
     public sealed partial class BooleanCell
     {
         /// <summary>
-        /// The value of the cell as a boolean.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("value")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required bool Value { get; set; }
-
-        /// <summary>
         /// The value of the cell that directly set by the user.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("userInput")]
@@ -37,9 +30,6 @@ namespace Instill
         /// <summary>
         /// Initializes a new instance of the <see cref="BooleanCell" /> class.
         /// </summary>
-        /// <param name="value">
-        /// The value of the cell as a boolean.
-        /// </param>
         /// <param name="userInput">
         /// The value of the cell that directly set by the user.
         /// </param>
@@ -51,11 +41,9 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public BooleanCell(
-            bool value,
             bool? userInput,
             bool? computedValue)
         {
-            this.Value = value;
             this.UserInput = userInput;
             this.ComputedValue = computedValue;
         }

--- a/src/libs/Instill/Generated/Instill.Models.NumberCell.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.NumberCell.g.cs
@@ -9,13 +9,6 @@ namespace Instill
     public sealed partial class NumberCell
     {
         /// <summary>
-        /// The value of the cell as a number.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("value")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required double Value { get; set; }
-
-        /// <summary>
         /// The value of the cell that directly set by the user.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("userInput")]
@@ -37,9 +30,6 @@ namespace Instill
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberCell" /> class.
         /// </summary>
-        /// <param name="value">
-        /// The value of the cell as a number.
-        /// </param>
         /// <param name="userInput">
         /// The value of the cell that directly set by the user.
         /// </param>
@@ -51,11 +41,9 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public NumberCell(
-            double value,
             double? userInput,
             double? computedValue)
         {
-            this.Value = value;
             this.UserInput = userInput;
             this.ComputedValue = computedValue;
         }

--- a/src/libs/Instill/Generated/Instill.Models.StringCell.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.StringCell.g.cs
@@ -9,13 +9,6 @@ namespace Instill
     public sealed partial class StringCell
     {
         /// <summary>
-        /// The value of the cell as a string.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("value")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required string Value { get; set; }
-
-        /// <summary>
         /// The value of the cell that directly set by the user.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("userInput")]
@@ -36,9 +29,6 @@ namespace Instill
         /// <summary>
         /// Initializes a new instance of the <see cref="StringCell" /> class.
         /// </summary>
-        /// <param name="value">
-        /// The value of the cell as a string.
-        /// </param>
         /// <param name="userInput">
         /// The value of the cell that directly set by the user.
         /// </param>
@@ -49,11 +39,9 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public StringCell(
-            string value,
             string? userInput,
             string? computedValue)
         {
-            this.Value = value ?? throw new global::System.ArgumentNullException(nameof(value));
             this.UserInput = userInput;
             this.ComputedValue = computedValue;
         }

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -7348,13 +7348,8 @@ components:
       type: object
       description: BindChatTableResponse is an empty response for binding a table to a chat.
     BooleanCell:
-      required:
-        - value
       type: object
       properties:
-        value:
-          type: boolean
-          description: The value of the cell as a boolean.
         userInput:
           type: boolean
           description: The value of the cell that directly set by the user.
@@ -10980,14 +10975,8 @@ components:
       type: string
       description: "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`."
     NumberCell:
-      required:
-        - value
       type: object
       properties:
-        value:
-          type: number
-          description: The value of the cell as a number.
-          format: double
         userInput:
           type: number
           description: The value of the cell that directly set by the user.
@@ -12047,13 +12036,8 @@ components:
           readOnly: true
       description: Spec represents a specification data model.
     StringCell:
-      required:
-        - value
       type: object
       properties:
-        value:
-          type: string
-          description: The value of the cell as a string.
         userInput:
           type: string
           description: The value of the cell that directly set by the user.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated data cell schemas to use only user input and computed value fields, removing the previous value property from Boolean, Number, and String cells. This streamlines the way cell values are represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->