### PR TITLE
feat:Rename PLAN_PRO to PLAN_STARTER in UserSubscription.Plan enum and descriptions

### DIFF
--- a/src/libs/Instill/Generated/Instill.Models.UserSubscriptionPlan.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.UserSubscriptionPlan.g.cs
@@ -6,7 +6,7 @@ namespace Instill
     /// <summary>
     /// Enumerates the plan types for the user subscription.<br/>
     ///  - PLAN_FREE: Free plan.<br/>
-    ///  - PLAN_PRO: Pro plan.
+    ///  - PLAN_STARTER: Starter plan.
     /// </summary>
     public enum UserSubscriptionPlan
     {
@@ -15,9 +15,9 @@ namespace Instill
         /// </summary>
         PLANFREE,
         /// <summary>
-        /// Pro plan.
+        /// Starter plan.
         /// </summary>
-        PLANPRO,
+        PLANSTARTER,
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ namespace Instill
             return value switch
             {
                 UserSubscriptionPlan.PLANFREE => "PLAN_FREE",
-                UserSubscriptionPlan.PLANPRO => "PLAN_PRO",
+                UserSubscriptionPlan.PLANSTARTER => "PLAN_STARTER",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -45,7 +45,7 @@ namespace Instill
             return value switch
             {
                 "PLAN_FREE" => UserSubscriptionPlan.PLANFREE,
-                "PLAN_PRO" => UserSubscriptionPlan.PLANPRO,
+                "PLAN_STARTER" => UserSubscriptionPlan.PLANSTARTER,
                 _ => null,
             };
         }

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -12955,9 +12955,9 @@ components:
     UserSubscription.Plan:
       enum:
         - PLAN_FREE
-        - PLAN_PRO
+        - PLAN_STARTER
       type: string
-      description: "Enumerates the plan types for the user subscription.\n\n - PLAN_FREE: Free plan.\n - PLAN_PRO: Pro plan."
+      description: "Enumerates the plan types for the user subscription.\n\n - PLAN_FREE: Free plan.\n - PLAN_STARTER: Starter plan."
     ValidateNamespacePipelineBody:
       type: object
       description: "ValidateNamespacePipelineRequest represents a request to validate a pipeline\nowned by a user."


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated references from "Pro plan" to "Starter plan" in user subscription plan descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->