### PR TITLE
feat:Add read-only errorMessage property to Cell schema in OpenAPI spec

### DIFF
--- a/src/libs/Instill/Generated/Instill.Models.Cell.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.Cell.g.cs
@@ -114,6 +114,13 @@ namespace Instill
         public global::Instill.LockState? LockState { get; set; }
 
         /// <summary>
+        /// The error message of the cell.<br/>
+        /// Included only in responses
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -179,6 +186,10 @@ namespace Instill
         /// The lock state of the cell.<br/>
         /// Included only in responses
         /// </param>
+        /// <param name="errorMessage">
+        /// The error message of the cell.<br/>
+        /// Included only in responses
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
@@ -197,7 +208,8 @@ namespace Instill
             global::Instill.CellStatus? status,
             global::System.Collections.Generic.IList<global::Instill.Citation>? citations,
             global::Instill.Transparency? transparency,
-            global::Instill.LockState? lockState)
+            global::Instill.LockState? lockState,
+            string? errorMessage)
         {
             this.Uid = uid;
             this.ColumnUid = columnUid;
@@ -214,6 +226,7 @@ namespace Instill
             this.Citations = citations;
             this.Transparency = transparency;
             this.LockState = lockState;
+            this.ErrorMessage = errorMessage;
         }
 
         /// <summary>

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -7664,6 +7664,10 @@ components:
             - $ref: '#/components/schemas/LockState'
           description: The lock state of the cell.
           readOnly: true
+        errorMessage:
+          type: string
+          description: The error message of the cell.
+          readOnly: true
       description: Cell represents a cell in a table.
     CellStatus:
       enum:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an error message field for cells, allowing users to view error details associated with individual cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->