### PR TITLE
feat:Add optional convertingPipelines property to CreateCatalogBody and UpdateCatalogBody

### DIFF
--- a/src/libs/Instill/Generated/Instill.ArtifactClient.UpdateCatalog.g.cs
+++ b/src/libs/Instill/Generated/Instill.ArtifactClient.UpdateCatalog.g.cs
@@ -267,6 +267,32 @@ namespace Instill
         /// <param name="tags">
         /// The catalog tags.
         /// </param>
+        /// <param name="convertingPipelines">
+        /// Pipelines used for converting documents (i.e., files with pdf, doc[x] or<br/>
+        /// ppt[x] extension) to Markdown. The strings in the list identify the<br/>
+        /// pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.<br/>
+        /// The pipeline recipes MUST have the following variable and output fields:<br/>
+        /// ```yaml variable<br/>
+        /// variable:<br/>
+        ///   document_input:<br/>
+        ///     title: document-input<br/>
+        ///     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)<br/>
+        ///     type: file<br/>
+        /// ```<br/>
+        /// ```yaml output<br/>
+        /// output:<br/>
+        ///  convert_result:<br/>
+        ///    title: convert-result<br/>
+        ///    value: ${merge-markdown-refinement.output.results[0]}<br/>
+        /// ```<br/>
+        /// Other variable and output fields will be ignored.<br/>
+        /// The pipelines will be executed in order until one produces a successful,<br/>
+        /// non-empty result.<br/>
+        /// If no pipelines are provided, a default pipeline will be used. For<br/>
+        /// non-document catalog files, the conversion pipeline is deterministic (such<br/>
+        /// files are typically trivial to convert and don't require a dedicated<br/>
+        /// pipeline to improve the conversion performance).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
 #if NET8_0_OR_GREATER
@@ -277,12 +303,14 @@ namespace Instill
             string catalogId,
             string? description = default,
             global::System.Collections.Generic.IList<string>? tags = default,
+            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Instill.UpdateCatalogBody
             {
                 Description = description,
                 Tags = tags,
+                ConvertingPipelines = convertingPipelines,
             };
 
             return await UpdateCatalogAsync(

--- a/src/libs/Instill/Generated/Instill.IArtifactClient.UpdateCatalog.g.cs
+++ b/src/libs/Instill/Generated/Instill.IArtifactClient.UpdateCatalog.g.cs
@@ -34,6 +34,32 @@ namespace Instill
         /// <param name="tags">
         /// The catalog tags.
         /// </param>
+        /// <param name="convertingPipelines">
+        /// Pipelines used for converting documents (i.e., files with pdf, doc[x] or<br/>
+        /// ppt[x] extension) to Markdown. The strings in the list identify the<br/>
+        /// pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.<br/>
+        /// The pipeline recipes MUST have the following variable and output fields:<br/>
+        /// ```yaml variable<br/>
+        /// variable:<br/>
+        ///   document_input:<br/>
+        ///     title: document-input<br/>
+        ///     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)<br/>
+        ///     type: file<br/>
+        /// ```<br/>
+        /// ```yaml output<br/>
+        /// output:<br/>
+        ///  convert_result:<br/>
+        ///    title: convert-result<br/>
+        ///    value: ${merge-markdown-refinement.output.results[0]}<br/>
+        /// ```<br/>
+        /// Other variable and output fields will be ignored.<br/>
+        /// The pipelines will be executed in order until one produces a successful,<br/>
+        /// non-empty result.<br/>
+        /// If no pipelines are provided, a default pipeline will be used. For<br/>
+        /// non-document catalog files, the conversion pipeline is deterministic (such<br/>
+        /// files are typically trivial to convert and don't require a dedicated<br/>
+        /// pipeline to improve the conversion performance).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
 #if NET8_0_OR_GREATER
@@ -44,6 +70,7 @@ namespace Instill
             string catalogId,
             string? description = default,
             global::System.Collections.Generic.IList<string>? tags = default,
+            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Instill/Generated/Instill.Models.UpdateCatalogBody.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.UpdateCatalogBody.g.cs
@@ -21,6 +21,35 @@ namespace Instill
         public global::System.Collections.Generic.IList<string>? Tags { get; set; }
 
         /// <summary>
+        /// Pipelines used for converting documents (i.e., files with pdf, doc[x] or<br/>
+        /// ppt[x] extension) to Markdown. The strings in the list identify the<br/>
+        /// pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.<br/>
+        /// The pipeline recipes MUST have the following variable and output fields:<br/>
+        /// ```yaml variable<br/>
+        /// variable:<br/>
+        ///   document_input:<br/>
+        ///     title: document-input<br/>
+        ///     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)<br/>
+        ///     type: file<br/>
+        /// ```<br/>
+        /// ```yaml output<br/>
+        /// output:<br/>
+        ///  convert_result:<br/>
+        ///    title: convert-result<br/>
+        ///    value: ${merge-markdown-refinement.output.results[0]}<br/>
+        /// ```<br/>
+        /// Other variable and output fields will be ignored.<br/>
+        /// The pipelines will be executed in order until one produces a successful,<br/>
+        /// non-empty result.<br/>
+        /// If no pipelines are provided, a default pipeline will be used. For<br/>
+        /// non-document catalog files, the conversion pipeline is deterministic (such<br/>
+        /// files are typically trivial to convert and don't require a dedicated<br/>
+        /// pipeline to improve the conversion performance).
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("convertingPipelines")]
+        public global::System.Collections.Generic.IList<string>? ConvertingPipelines { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -35,15 +64,43 @@ namespace Instill
         /// <param name="tags">
         /// The catalog tags.
         /// </param>
+        /// <param name="convertingPipelines">
+        /// Pipelines used for converting documents (i.e., files with pdf, doc[x] or<br/>
+        /// ppt[x] extension) to Markdown. The strings in the list identify the<br/>
+        /// pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.<br/>
+        /// The pipeline recipes MUST have the following variable and output fields:<br/>
+        /// ```yaml variable<br/>
+        /// variable:<br/>
+        ///   document_input:<br/>
+        ///     title: document-input<br/>
+        ///     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)<br/>
+        ///     type: file<br/>
+        /// ```<br/>
+        /// ```yaml output<br/>
+        /// output:<br/>
+        ///  convert_result:<br/>
+        ///    title: convert-result<br/>
+        ///    value: ${merge-markdown-refinement.output.results[0]}<br/>
+        /// ```<br/>
+        /// Other variable and output fields will be ignored.<br/>
+        /// The pipelines will be executed in order until one produces a successful,<br/>
+        /// non-empty result.<br/>
+        /// If no pipelines are provided, a default pipeline will be used. For<br/>
+        /// non-document catalog files, the conversion pipeline is deterministic (such<br/>
+        /// files are typically trivial to convert and don't require a dedicated<br/>
+        /// pipeline to improve the conversion performance).
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public UpdateCatalogBody(
             string? description,
-            global::System.Collections.Generic.IList<string>? tags)
+            global::System.Collections.Generic.IList<string>? tags,
+            global::System.Collections.Generic.IList<string>? convertingPipelines)
         {
             this.Description = description;
             this.Tags = tags;
+            this.ConvertingPipelines = convertingPipelines;
         }
 
         /// <summary>

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -13038,6 +13038,11 @@ components:
           items:
             type: string
           description: The catalog tags.
+        convertingPipelines:
+          type: array
+          items:
+            type: string
+          description: "Pipelines used for converting documents (i.e., files with pdf, doc[x] or\nppt[x] extension) to Markdown. The strings in the list identify the\npipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.\nThe pipeline recipes MUST have the following variable and output fields:\n```yaml variable\nvariable:\n  document_input:\n    title: document-input\n    description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)\n    type: file\n```\n```yaml output\noutput:\n convert_result:\n   title: convert-result\n   value: ${merge-markdown-refinement.output.results[0]}\n```\nOther variable and output fields will be ignored.\n\nThe pipelines will be executed in order until one produces a successful,\nnon-empty result.\n\nIf no pipelines are provided, a default pipeline will be used. For\nnon-document catalog files, the conversion pipeline is deterministic (such\nfiles are typically trivial to convert and don't require a dedicated\npipeline to improve the conversion performance)."
       description: UpdateCatalogRequest represents a request to update a catalog.
     UpdateCatalogResponse:
       type: object


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying custom document conversion pipelines when creating or updating a catalog. Users can now provide a list of pipeline identifiers to handle file conversions (e.g., PDF, DOCX, PPTX to Markdown). If no pipelines are specified, a default conversion pipeline will be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->