### PR TITLE
feat:Rename catalogId to catalogUid in ChatContext.Catalog OpenAPI schema

### DIFF
--- a/src/libs/Instill/Generated/Instill.Models.ChatContextCatalog.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.ChatContextCatalog.g.cs
@@ -11,9 +11,9 @@ namespace Instill
         /// <summary>
         /// 
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("catalogId")]
+        [global::System.Text.Json.Serialization.JsonPropertyName("catalogUid")]
         [global::System.Text.Json.Serialization.JsonRequired]
-        public required string CatalogId { get; set; }
+        public required string CatalogUid { get; set; }
 
         /// <summary>
         /// 
@@ -30,16 +30,16 @@ namespace Instill
         /// <summary>
         /// Initializes a new instance of the <see cref="ChatContextCatalog" /> class.
         /// </summary>
-        /// <param name="catalogId"></param>
+        /// <param name="catalogUid"></param>
         /// <param name="fileUids"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public ChatContextCatalog(
-            string catalogId,
+            string catalogUid,
             global::System.Collections.Generic.IList<string>? fileUids)
         {
-            this.CatalogId = catalogId ?? throw new global::System.ArgumentNullException(nameof(catalogId));
+            this.CatalogUid = catalogUid ?? throw new global::System.ArgumentNullException(nameof(catalogUid));
             this.FileUids = fileUids;
         }
 

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -7902,10 +7902,10 @@ components:
       description: The context for the message.
     ChatContext.Catalog:
       required:
-        - catalogId
+        - catalogUid
       type: object
       properties:
-        catalogId:
+        catalogUid:
           title: The catalog containing the files
           type: string
         fileUids:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the property in the ChatContext.Catalog component from "catalogId" to "catalogUid" in the API schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->