### PR TITLE
feat:Remove fileName fileUid from SimilarityChunk and SearchBody in OpenAPI

### DIFF
--- a/src/libs/Instill/Generated/Instill.ArtifactClient.SimilarityChunksSearch.g.cs
+++ b/src/libs/Instill/Generated/Instill.ArtifactClient.SimilarityChunksSearch.g.cs
@@ -280,20 +280,11 @@ namespace Instill
         /// <param name="topK">
         /// Top K. Default value: 5.
         /// </param>
-        /// <param name="fileName">
-        /// File name. This field is deprecated as the file ID isn't a unique<br/>
-        /// identifier within a catalog. The file UID should be used, instead.<br/>
-        /// When this file is provided, the service will search a file by UID and<br/>
-        /// it'll use the UID in the first match.
-        /// </param>
         /// <param name="contentType">
         /// Content type.
         /// </param>
         /// <param name="fileMediaType">
         /// File type.
-        /// </param>
-        /// <param name="fileUid">
-        /// File UID. This field is deprecated, the file_uids should be used instead.
         /// </param>
         /// <param name="fileUids">
         /// File UIDs. When this field is provided, the response will return only<br/>
@@ -310,10 +301,8 @@ namespace Instill
             string textPrompt,
             string? instillRequesterUid = default,
             long? topK = default,
-            string? fileName = default,
             global::Instill.ContentType? contentType = default,
             global::Instill.FileMediaType? fileMediaType = default,
-            string? fileUid = default,
             global::System.Collections.Generic.IList<string>? fileUids = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
@@ -321,10 +310,8 @@ namespace Instill
             {
                 TextPrompt = textPrompt,
                 TopK = topK,
-                FileName = fileName,
                 ContentType = contentType,
                 FileMediaType = fileMediaType,
-                FileUid = fileUid,
                 FileUids = fileUids,
             };
 

--- a/src/libs/Instill/Generated/Instill.IArtifactClient.SimilarityChunksSearch.g.cs
+++ b/src/libs/Instill/Generated/Instill.IArtifactClient.SimilarityChunksSearch.g.cs
@@ -37,20 +37,11 @@ namespace Instill
         /// <param name="topK">
         /// Top K. Default value: 5.
         /// </param>
-        /// <param name="fileName">
-        /// File name. This field is deprecated as the file ID isn't a unique<br/>
-        /// identifier within a catalog. The file UID should be used, instead.<br/>
-        /// When this file is provided, the service will search a file by UID and<br/>
-        /// it'll use the UID in the first match.
-        /// </param>
         /// <param name="contentType">
         /// Content type.
         /// </param>
         /// <param name="fileMediaType">
         /// File type.
-        /// </param>
-        /// <param name="fileUid">
-        /// File UID. This field is deprecated, the file_uids should be used instead.
         /// </param>
         /// <param name="fileUids">
         /// File UIDs. When this field is provided, the response will return only<br/>
@@ -67,10 +58,8 @@ namespace Instill
             string textPrompt,
             string? instillRequesterUid = default,
             long? topK = default,
-            string? fileName = default,
             global::Instill.ContentType? contentType = default,
             global::Instill.FileMediaType? fileMediaType = default,
-            string? fileUid = default,
             global::System.Collections.Generic.IList<string>? fileUids = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }

--- a/src/libs/Instill/Generated/Instill.Models.SimilarityChunksSearchBody.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.SimilarityChunksSearchBody.g.cs
@@ -22,15 +22,6 @@ namespace Instill
         public long? TopK { get; set; }
 
         /// <summary>
-        /// File name. This field is deprecated as the file ID isn't a unique<br/>
-        /// identifier within a catalog. The file UID should be used, instead.<br/>
-        /// When this file is provided, the service will search a file by UID and<br/>
-        /// it'll use the UID in the first match.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("fileName")]
-        public string? FileName { get; set; }
-
-        /// <summary>
         /// Content type.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("contentType")]
@@ -43,12 +34,6 @@ namespace Instill
         [global::System.Text.Json.Serialization.JsonPropertyName("fileMediaType")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Instill.JsonConverters.FileMediaTypeJsonConverter))]
         public global::Instill.FileMediaType? FileMediaType { get; set; }
-
-        /// <summary>
-        /// File UID. This field is deprecated, the file_uids should be used instead.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("fileUid")]
-        public string? FileUid { get; set; }
 
         /// <summary>
         /// File UIDs. When this field is provided, the response will return only<br/>
@@ -72,20 +57,11 @@ namespace Instill
         /// <param name="topK">
         /// Top K. Default value: 5.
         /// </param>
-        /// <param name="fileName">
-        /// File name. This field is deprecated as the file ID isn't a unique<br/>
-        /// identifier within a catalog. The file UID should be used, instead.<br/>
-        /// When this file is provided, the service will search a file by UID and<br/>
-        /// it'll use the UID in the first match.
-        /// </param>
         /// <param name="contentType">
         /// Content type.
         /// </param>
         /// <param name="fileMediaType">
         /// File type.
-        /// </param>
-        /// <param name="fileUid">
-        /// File UID. This field is deprecated, the file_uids should be used instead.
         /// </param>
         /// <param name="fileUids">
         /// File UIDs. When this field is provided, the response will return only<br/>
@@ -97,18 +73,14 @@ namespace Instill
         public SimilarityChunksSearchBody(
             string textPrompt,
             long? topK,
-            string? fileName,
             global::Instill.ContentType? contentType,
             global::Instill.FileMediaType? fileMediaType,
-            string? fileUid,
             global::System.Collections.Generic.IList<string>? fileUids)
         {
             this.TextPrompt = textPrompt ?? throw new global::System.ArgumentNullException(nameof(textPrompt));
             this.TopK = topK;
-            this.FileName = fileName;
             this.ContentType = contentType;
             this.FileMediaType = fileMediaType;
-            this.FileUid = fileUid;
             this.FileUids = fileUids;
         }
 

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -12763,9 +12763,6 @@ components:
           type: integer
           description: 'Top K. Default value: 5.'
           format: int64
-        fileName:
-          type: string
-          description: "File name. This field is deprecated as the file ID isn't a unique\nidentifier within a catalog. The file UID should be used, instead.\nWhen this file is provided, the service will search a file by UID and\nit'll use the UID in the first match."
         contentType:
           allOf:
             - $ref: '#/components/schemas/ContentType'
@@ -12774,9 +12771,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/FileMediaType'
           description: File type.
-        fileUid:
-          type: string
-          description: 'File UID. This field is deprecated, the file_uids should be used instead.'
         fileUids:
           type: array
           items:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Breaking Changes
  * Removed fileName and fileUid from Similarity API chunk results.
  * Removed fileName and fileUid filters from Similarity search requests.
  * Continue using existing filters (e.g., topK, textPrompt, fileUids) to constrain results.
  * No other API fields or endpoints are affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->