### PR TITLE
feat:Rename convertingPipelines to convertingPipeline; array to string

### DIFF
--- a/src/libs/Instill/Generated/Instill.ArtifactClient.UploadCatalogFile.g.cs
+++ b/src/libs/Instill/Generated/Instill.ArtifactClient.UploadCatalogFile.g.cs
@@ -9,14 +9,14 @@ namespace Instill
             global::System.Net.Http.HttpClient httpClient,
             ref string namespaceId,
             ref string catalogId,
-            global::System.Collections.Generic.IList<string>? convertingPipelines,
+            ref string? convertingPipeline,
             global::Instill.File request);
         partial void PrepareUploadCatalogFileRequest(
             global::System.Net.Http.HttpClient httpClient,
             global::System.Net.Http.HttpRequestMessage httpRequestMessage,
             string namespaceId,
             string catalogId,
-            global::System.Collections.Generic.IList<string>? convertingPipelines,
+            string? convertingPipeline,
             global::Instill.File request);
         partial void ProcessUploadCatalogFileResponse(
             global::System.Net.Http.HttpClient httpClient,
@@ -33,7 +33,7 @@ namespace Instill
         /// </summary>
         /// <param name="namespaceId"></param>
         /// <param name="catalogId"></param>
-        /// <param name="convertingPipelines"></param>
+        /// <param name="convertingPipeline"></param>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Instill.ApiException"></exception>
@@ -44,7 +44,7 @@ namespace Instill
             string namespaceId,
             string catalogId,
             global::Instill.File request,
-            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
+            string? convertingPipeline = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             request = request ?? throw new global::System.ArgumentNullException(nameof(request));
@@ -55,14 +55,14 @@ namespace Instill
                 httpClient: HttpClient,
                 namespaceId: ref namespaceId,
                 catalogId: ref catalogId,
-                convertingPipelines: convertingPipelines,
+                convertingPipeline: ref convertingPipeline,
                 request: request);
 
             var __pathBuilder = new global::Instill.PathBuilder(
                 path: $"/v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files",
                 baseUri: HttpClient.BaseAddress); 
             __pathBuilder 
-                .AddOptionalParameter("convertingPipelines", convertingPipelines, delimiter: ",", explode: true) 
+                .AddOptionalParameter("convertingPipeline", convertingPipeline) 
                 ; 
             var __path = __pathBuilder.ToString();
             using var __httpRequest = new global::System.Net.Http.HttpRequestMessage(
@@ -103,7 +103,7 @@ namespace Instill
                 httpRequestMessage: __httpRequest,
                 namespaceId: namespaceId,
                 catalogId: catalogId,
-                convertingPipelines: convertingPipelines,
+                convertingPipeline: convertingPipeline,
                 request: request);
 
             using var __response = await HttpClient.SendAsync(
@@ -270,7 +270,7 @@ namespace Instill
         /// </summary>
         /// <param name="namespaceId"></param>
         /// <param name="catalogId"></param>
-        /// <param name="convertingPipelines"></param>
+        /// <param name="convertingPipeline"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
         /// <param name="content"></param>
@@ -287,7 +287,7 @@ namespace Instill
         public async global::System.Threading.Tasks.Task<global::Instill.UploadCatalogFileResponse> UploadCatalogFileAsync(
             string namespaceId,
             string catalogId,
-            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
+            string? convertingPipeline = default,
             string? name = default,
             global::Instill.FileType? type = default,
             string? content = default,
@@ -307,7 +307,7 @@ namespace Instill
             return await UploadCatalogFileAsync(
                 namespaceId: namespaceId,
                 catalogId: catalogId,
-                convertingPipelines: convertingPipelines,
+                convertingPipeline: convertingPipeline,
                 request: __request,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/libs/Instill/Generated/Instill.IArtifactClient.UploadCatalogFile.g.cs
+++ b/src/libs/Instill/Generated/Instill.IArtifactClient.UploadCatalogFile.g.cs
@@ -10,7 +10,7 @@ namespace Instill
         /// </summary>
         /// <param name="namespaceId"></param>
         /// <param name="catalogId"></param>
-        /// <param name="convertingPipelines"></param>
+        /// <param name="convertingPipeline"></param>
         /// <param name="request"></param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::Instill.ApiException"></exception>
@@ -21,7 +21,7 @@ namespace Instill
             string namespaceId,
             string catalogId,
             global::Instill.File request,
-            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
+            string? convertingPipeline = default,
             global::System.Threading.CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Instill
         /// </summary>
         /// <param name="namespaceId"></param>
         /// <param name="catalogId"></param>
-        /// <param name="convertingPipelines"></param>
+        /// <param name="convertingPipeline"></param>
         /// <param name="name"></param>
         /// <param name="type"></param>
         /// <param name="content"></param>
@@ -47,7 +47,7 @@ namespace Instill
         global::System.Threading.Tasks.Task<global::Instill.UploadCatalogFileResponse> UploadCatalogFileAsync(
             string namespaceId,
             string catalogId,
-            global::System.Collections.Generic.IList<string>? convertingPipelines = default,
+            string? convertingPipeline = default,
             string? name = default,
             global::Instill.FileType? type = default,
             string? content = default,

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -2684,14 +2684,11 @@ paths:
           required: true
           schema:
             type: string
-        - name: convertingPipelines
+        - name: convertingPipeline
           in: query
-          description: "Pipelines used for converting the document file (i.e., files with pdf,\ndoc[x] or ppt[x] extension) to Markdown. The strings in the list identify\nthe pipelines and MUST have the format\n`{namespaceID}/{pipelineID}@{version}`.\nThe pipeline recipes MUST have the following variable and output fields:\n```yaml variable\nvariable:\n  document_input:\n    title: document-input\n    description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)\n    type: file\n```\n```yaml output\noutput:\n convert_result:\n   title: convert-result\n   value: ${merge-markdown-refinement.output.results[0]}\n```\nOther variable and output fields will be ignored.\n\nThe pipelines will be executed in order until one produces a successful,\nnon-empty result.\n\nIf no pipelines are provided, the catalog's conversion pipelines will be\nused (see the catalog creation request).\n\nFor non-document catalog files, the conversion pipeline is deterministic\n(such files are typically trivial to convert and don't require a dedicated\npipeline to improve the conversion performance)."
-          style: form
+          description: "Pipeline used for converting the file to Markdown if the file is a\ndocument (i.e., a file with pdf, doc[x] or ppt[x] extension). The value\nidentifies the pipeline release and and MUST have the format\n`{namespaceID}/{pipelineID}@{version}`.\nThe pipeline recipe MUST have the following variable and output fields:\n```yaml variable\nvariable:\n  document_input:\n    title: document-input\n    description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)\n    type: file\n```\n```yaml output\noutput:\n convert_result:\n   title: convert-result\n   value: ${merge-markdown-refinement.output.results[0]}\n```\nOther variable and output fields will be ignored.\n\nThe pipeline will be executed first, falling back to the catalog's\nconversion pipelines if the conversion doesn't yield a non-empty result\n(see the catalog creation endpoint documentation).\n\nFor non-document catalog files, the conversion pipeline is deterministic\n(such files are typically trivial to convert and don't require a dedicated\npipeline to improve the conversion performance)."
           schema:
-            type: array
-            items:
-              type: string
+            type: string
       requestBody:
         description: file
         content:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public API updated: CreateCatalogBody now uses convertingPipeline (string) instead of convertingPipelines (array).
- Refactor
  - Parameter simplified from list to single value; request formatting adjusted accordingly.
  - Updated behavior: attempts the specified pipeline first, then falls back to catalog pipelines if no non-empty result.
- Documentation
  - Revised field description to reflect single-pipeline usage, including required format {namespaceID}/{pipelineID}@{version} and details on embedded document_input/output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->