### PR TITLE
feat:Add Position schema, remove FilePosition, update references

### DIFF
--- a/src/libs/Instill/Generated/Instill.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Instill/Generated/Instill.JsonSerializerContextTypes.g.cs
@@ -410,7 +410,7 @@ namespace Instill
         /// <summary>
         /// 
         /// </summary>
-        public global::Instill.FilePosition? Type96 { get; set; }
+        public global::Instill.Position? Type96 { get; set; }
         /// <summary>
         /// 
         /// </summary>

--- a/src/libs/Instill/Generated/Instill.Models.File.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.File.g.cs
@@ -163,13 +163,13 @@ namespace Instill
         public string? ConvertingPipeline { get; set; }
 
         /// <summary>
-        /// Length of the file in the specified unit type. It is defined as a<br/>
-        /// FilePosition, so it reflects the number of positions (the unit will depend<br/>
-        /// on the file type) that can be accessed in the file.<br/>
+        /// Length of the file in the specified unit type. It is defined as the number<br/>
+        /// of positions (the unit will depend on the file type) that can be accessed<br/>
+        /// in the file.<br/>
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("length")]
-        public global::Instill.FilePosition? Length { get; set; }
+        public global::Instill.Position? Length { get; set; }
 
         /// <summary>
         /// Additional properties that are not explicitly defined in the schema
@@ -261,9 +261,9 @@ namespace Instill
         /// pipeline to improve the conversion performance).
         /// </param>
         /// <param name="length">
-        /// Length of the file in the specified unit type. It is defined as a<br/>
-        /// FilePosition, so it reflects the number of positions (the unit will depend<br/>
-        /// on the file type) that can be accessed in the file.<br/>
+        /// Length of the file in the specified unit type. It is defined as the number<br/>
+        /// of positions (the unit will depend on the file type) that can be accessed<br/>
+        /// in the file.<br/>
         /// Included only in responses
         /// </param>
 #if NET7_0_OR_GREATER
@@ -290,7 +290,7 @@ namespace Instill
             string? summary,
             string? downloadUrl,
             string? convertingPipeline,
-            global::Instill.FilePosition? length,
+            global::Instill.Position? length,
             string fileUid = default!)
         {
             this.FileUid = fileUid;

--- a/src/libs/Instill/Generated/Instill.Models.Position.Json.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.Position.Json.g.cs
@@ -2,7 +2,7 @@
 
 namespace Instill
 {
-    public sealed partial class FilePosition
+    public sealed partial class Position
     {
         /// <summary>
         /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
@@ -34,14 +34,14 @@ namespace Instill
         /// <summary>
         /// Deserializes a JSON string using the provided JsonSerializerContext.
         /// </summary>
-        public static global::Instill.FilePosition? FromJson(
+        public static global::Instill.Position? FromJson(
             string json,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return global::System.Text.Json.JsonSerializer.Deserialize(
                 json,
-                typeof(global::Instill.FilePosition),
-                jsonSerializerContext) as global::Instill.FilePosition;
+                typeof(global::Instill.Position),
+                jsonSerializerContext) as global::Instill.Position;
         }
 
         /// <summary>
@@ -51,11 +51,11 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::Instill.FilePosition? FromJson(
+        public static global::Instill.Position? FromJson(
             string json,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.Deserialize<global::Instill.FilePosition>(
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Instill.Position>(
                 json,
                 jsonSerializerOptions);
         }
@@ -63,14 +63,14 @@ namespace Instill
         /// <summary>
         /// Deserializes a JSON stream using the provided JsonSerializerContext.
         /// </summary>
-        public static async global::System.Threading.Tasks.ValueTask<global::Instill.FilePosition?> FromJsonStreamAsync(
+        public static async global::System.Threading.Tasks.ValueTask<global::Instill.Position?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
         {
             return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
                 jsonStream,
-                typeof(global::Instill.FilePosition),
-                jsonSerializerContext).ConfigureAwait(false)) as global::Instill.FilePosition;
+                typeof(global::Instill.Position),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Instill.Position;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
         [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 #endif
-        public static global::System.Threading.Tasks.ValueTask<global::Instill.FilePosition?> FromJsonStreamAsync(
+        public static global::System.Threading.Tasks.ValueTask<global::Instill.Position?> FromJsonStreamAsync(
             global::System.IO.Stream jsonStream,
             global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
         {
-            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Instill.FilePosition?>(
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Instill.Position?>(
                 jsonStream,
                 jsonSerializerOptions);
         }

--- a/src/libs/Instill/Generated/Instill.Models.Position.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.Position.g.cs
@@ -4,11 +4,13 @@
 namespace Instill
 {
     /// <summary>
-    /// 
+    /// Position represents a position within a file using a specific unit. The<br/>
+    /// number of dimensions of the position value depends on the unit type.
     /// </summary>
-    public sealed partial class FilePosition
+    public sealed partial class Position
     {
         /// <summary>
+        /// Unit of measurement for the position.<br/>
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("unit")]
@@ -16,10 +18,7 @@ namespace Instill
         public global::Instill.Unit? Unit { get; set; }
 
         /// <summary>
-        /// Position coordinates as an array<br/>
-        /// For 1D: [position]<br/>
-        /// For 2D: [x, y]<br/>
-        /// For 3D: [x, y, z], etc.<br/>
+        /// Position value.<br/>
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("coordinates")]
@@ -32,22 +31,20 @@ namespace Instill
         public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilePosition" /> class.
+        /// Initializes a new instance of the <see cref="Position" /> class.
         /// </summary>
         /// <param name="unit">
+        /// Unit of measurement for the position.<br/>
         /// Included only in responses
         /// </param>
         /// <param name="coordinates">
-        /// Position coordinates as an array<br/>
-        /// For 1D: [position]<br/>
-        /// For 2D: [x, y]<br/>
-        /// For 3D: [x, y, z], etc.<br/>
+        /// Position value.<br/>
         /// Included only in responses
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
-        public FilePosition(
+        public Position(
             global::Instill.Unit? unit,
             global::System.Collections.Generic.IList<long>? coordinates)
         {
@@ -56,9 +53,9 @@ namespace Instill
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilePosition" /> class.
+        /// Initializes a new instance of the <see cref="Position" /> class.
         /// </summary>
-        public FilePosition()
+        public Position()
         {
         }
     }

--- a/src/libs/Instill/Generated/Instill.Models.Reference.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.Reference.g.cs
@@ -4,7 +4,7 @@
 namespace Instill
 {
     /// <summary>
-    /// Reference represents the position of a chunk within its source file.
+    /// Reference represents the position of a chunk within a file.
     /// </summary>
     public sealed partial class Reference
     {
@@ -13,14 +13,14 @@ namespace Instill
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("start")]
-        public global::Instill.FilePosition? Start { get; set; }
+        public global::Instill.Position? Start { get; set; }
 
         /// <summary>
         /// End position of the chunk within the file.<br/>
         /// Included only in responses
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("end")]
-        public global::Instill.FilePosition? End { get; set; }
+        public global::Instill.Position? End { get; set; }
 
         /// <summary>
         /// Additional properties that are not explicitly defined in the schema
@@ -43,8 +43,8 @@ namespace Instill
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public Reference(
-            global::Instill.FilePosition? start,
-            global::Instill.FilePosition? end)
+            global::Instill.Position? start,
+            global::Instill.Position? end)
         {
             this.Start = start;
             this.End = end;

--- a/src/libs/Instill/Generated/Instill.Models.Unit.g.cs
+++ b/src/libs/Instill/Generated/Instill.Models.Unit.g.cs
@@ -4,7 +4,7 @@
 namespace Instill
 {
     /// <summary>
-    /// Unit describes the unit of measurement for a position within a file.<br/>
+    /// Unit of measurement for a position within a file.<br/>
     ///  - UNIT_CHARACTER: Character positions (for Markdown and other text files).<br/>
     ///  - UNIT_PAGE: Page positions (for documents).<br/>
     ///  - UNIT_TIME_MS: Time positions in milliseconds (for audio/video files).<br/>

--- a/src/libs/Instill/openapi.yaml
+++ b/src/libs/Instill/openapi.yaml
@@ -6143,8 +6143,8 @@ components:
           description: "Pipeline used for converting the file to Markdown if the file is a\ndocument (i.e., a file with pdf, doc[x] or ppt[x] extension). The value\nidentifies the pipeline release and and MUST have the format\n`{namespaceID}/{pipelineID}@{version}`.\nThe pipeline recipe MUST have the following variable and output fields:\n```yaml variable\nvariable:\n  document_input:\n    title: document-input\n    description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)\n    type: file\n```\n```yaml output\noutput:\n convert_result:\n   title: convert-result\n   value: ${merge-markdown-refinement.output.results[0]}\n```\nOther variable and output fields will be ignored.\n\nThe pipeline will be executed first, falling back to the catalog's\nconversion pipelines if the conversion doesn't yield a non-empty result\n(see the catalog creation endpoint documentation).\n\nFor non-document catalog files, the conversion pipeline is deterministic\n(such files are typically trivial to convert and don't require a dedicated\npipeline to improve the conversion performance)."
         length:
           allOf:
-            - $ref: '#/components/schemas/FilePosition'
-          description: "Length of the file in the specified unit type. It is defined as a\nFilePosition, so it reflects the number of positions (the unit will depend\non the file type) that can be accessed in the file."
+            - $ref: '#/components/schemas/Position'
+          description: "Length of the file in the specified unit type. It is defined as the number\nof positions (the unit will depend on the file type) that can be accessed\nin the file."
           readOnly: true
     FileMediaType:
       enum:
@@ -6186,22 +6186,6 @@ components:
           description: Processing status of the file.
           readOnly: true
       description: FileMetadata contains information about the file.
-    FilePosition:
-      title: "FilePosition represents a position within a file using a specific unit.\nThe position can be multi-dimensional based on the unit type:\n- 1 element for 1D positions (characters, pages, time)\n- 2 elements for 2D positions (pixels: [x, y])\n- N elements for N-dimensional positions"
-      type: object
-      properties:
-        unit:
-          title: Unit of measurement for the position
-          allOf:
-            - $ref: '#/components/schemas/Unit'
-          readOnly: true
-        coordinates:
-          type: array
-          items:
-            type: integer
-            format: int64
-          description: "Position coordinates as an array\nFor 1D: [position]\nFor 2D: [x, y]\nFor 3D: [x, y, z], etc."
-          readOnly: true
     FileProcessStatus:
       title: file embedding process status
       enum:
@@ -8274,6 +8258,22 @@ components:
           description: The ID of the namespace that requested the pipeline triggers.
           readOnly: true
       description: "PipelineTriggerChartRecord represents a timeline of pipeline triggers. It\ncontains a collection of (timestamp, count) pairs that represent the total\npipeline triggers in a given time bucket."
+    Position:
+      type: object
+      properties:
+        unit:
+          allOf:
+            - $ref: '#/components/schemas/Unit'
+          description: Unit of measurement for the position.
+          readOnly: true
+        coordinates:
+          type: array
+          items:
+            type: integer
+            format: int64
+          description: Position value.
+          readOnly: true
+      description: "Position represents a position within a file using a specific unit. The\nnumber of dimensions of the position value depends on the unit type."
     ProcessCatalogFilesRequest:
       title: Process Catalog File Request
       required:
@@ -8329,15 +8329,15 @@ components:
       properties:
         start:
           allOf:
-            - $ref: '#/components/schemas/FilePosition'
+            - $ref: '#/components/schemas/Position'
           description: Start position of the chunk within the file.
           readOnly: true
         end:
           allOf:
-            - $ref: '#/components/schemas/FilePosition'
+            - $ref: '#/components/schemas/Position'
           description: End position of the chunk within the file.
           readOnly: true
-      description: Reference represents the position of a chunk within its source file.
+      description: Reference represents the position of a chunk within a file.
     Region:
       type: object
       properties:
@@ -9014,7 +9014,7 @@ components:
         - UNIT_TIME_MS
         - UNIT_PIXEL
       type: string
-      description: "Unit describes the unit of measurement for a position within a file.\n\n - UNIT_CHARACTER: Character positions (for Markdown and other text files).\n - UNIT_PAGE: Page positions (for documents).\n - UNIT_TIME_MS: Time positions in milliseconds (for audio/video files).\n - UNIT_PIXEL: Pixel positions (for images and other 2D content)."
+      description: "Unit of measurement for a position within a file.\n\n - UNIT_CHARACTER: Character positions (for Markdown and other text files).\n - UNIT_PAGE: Page positions (for documents).\n - UNIT_TIME_MS: Time positions in milliseconds (for audio/video files).\n - UNIT_PIXEL: Pixel positions (for images and other 2D content)."
     UpdateCatalogBody:
       type: object
       properties:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced FilePosition with Position across the API schema, including Length and Reference fields.
  - Removed FilePosition type and introduced Position with unit and coordinates.
  - This change may require client updates where FilePosition was used.

- Documentation
  - Updated Reference description to clarify it represents a position within a file.
  - Revised Unit description text without altering enum values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->